### PR TITLE
Fixed Google Compute Engine disk config

### DIFF
--- a/gcloud/code/terraform/00-preface/hello-world/main.tf
+++ b/gcloud/code/terraform/00-preface/hello-world/main.tf
@@ -8,9 +8,13 @@ resource "google_compute_instance" "example" {
   name = "example"
   machine_type  = "f1-micro"
   zone = "us-central1-a"
-  disk {
-    image = "ubuntu-1604-lts"
+  
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1604-lts"
+    }
   }
+  
   network_interface {
     network = "default"
 

--- a/gcloud/code/terraform/02-intro-to-terraform-syntax/one-server/main.tf
+++ b/gcloud/code/terraform/02-intro-to-terraform-syntax/one-server/main.tf
@@ -1,14 +1,16 @@
 provider "google" {
-  project     = "terraform-up-and-running-code"
+  project = "terraform-up-and-running-code"
+
   # credentials = GOOGLE_CREDENTIALS
   region = "us-central1"
 }
 
 resource "google_compute_instance" "example" {
-  name = "terraform-example"
-  machine_type  = "f1-micro"
-  zone = "us-central1-a"
-   boot_disk {
+  name         = "terraform-example"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
     initialize_params {
       image = "ubuntu-1604-lts"
     }
@@ -21,5 +23,6 @@ resource "google_compute_instance" "example" {
       // Ephemeral IP
     }
   }
+
   tags = ["terraform-example"]
 }

--- a/gcloud/code/terraform/02-intro-to-terraform-syntax/one-server/main.tf
+++ b/gcloud/code/terraform/02-intro-to-terraform-syntax/one-server/main.tf
@@ -8,9 +8,12 @@ resource "google_compute_instance" "example" {
   name = "terraform-example"
   machine_type  = "f1-micro"
   zone = "us-central1-a"
-  disk {
-    image = "ubuntu-1604-lts"
+   boot_disk {
+    initialize_params {
+      image = "ubuntu-1604-lts"
+    }
   }
+
   network_interface {
     network = "default"
 

--- a/gcloud/code/terraform/02-intro-to-terraform-syntax/one-webserver-with-vars/main.tf
+++ b/gcloud/code/terraform/02-intro-to-terraform-syntax/one-webserver-with-vars/main.tf
@@ -1,16 +1,21 @@
 provider "google" {
-  project     = "terraform-up-and-running-code"
+  project = "terraform-up-and-running-code"
+
   # credentials = GOOGLE_CREDENTIALS
   region = "us-central1"
 }
 
 resource "google_compute_instance" "example" {
-  name = "terraform-example"
-  machine_type  = "f1-micro"
-  zone = "us-central1-a"
-  disk {
-    image = "ubuntu-1604-lts"
+  name         = "terraform-example"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1604-lts"
+    }
   }
+
   network_interface {
     network = "default"
 
@@ -18,6 +23,7 @@ resource "google_compute_instance" "example" {
       // Ephemeral IP
     }
   }
+
   tags = ["terraform-example"]
 
   metadata_startup_script = "echo 'Hello, World' > index.html ; nohup busybox httpd -f -p ${var.server_port} &"
@@ -33,4 +39,6 @@ resource "google_compute_firewall" "instance" {
     protocol = "tcp"
     ports    = ["${var.server_port}"]
   }
+
+  source_tags = ["terraform-example"]
 }

--- a/gcloud/code/terraform/02-intro-to-terraform-syntax/one-webserver/main.tf
+++ b/gcloud/code/terraform/02-intro-to-terraform-syntax/one-webserver/main.tf
@@ -1,16 +1,21 @@
 provider "google" {
-  project     = "terraform-up-and-running-code"
+  project = "terraform-up-and-running-code"
+
   # credentials = GOOGLE_CREDENTIALS
   region = "us-central1"
 }
 
 resource "google_compute_instance" "example" {
-  name = "terraform-example"
-  machine_type  = "f1-micro"
-  zone = "us-central1-a"
-  disk {
-    image = "ubuntu-1604-lts"
+  name         = "terraform-example"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-1604-lts"
+    }
   }
+
   network_interface {
     network = "default"
 
@@ -18,6 +23,7 @@ resource "google_compute_instance" "example" {
       // Ephemeral IP
     }
   }
+
   tags = ["terraform-example"]
 
   metadata_startup_script = "echo 'Hello, World' > index.html ; nohup busybox httpd -f -p 8080 &"
@@ -33,6 +39,8 @@ resource "google_compute_firewall" "instance" {
     protocol = "tcp"
     ports    = ["8080"]
   }
+
+  source_tags = ["terraform-example"]
 }
 
 output "public_ip" {

--- a/gcloud/code/terraform/02-intro-to-terraform-syntax/webserver-cluster/main.tf
+++ b/gcloud/code/terraform/02-intro-to-terraform-syntax/webserver-cluster/main.tf
@@ -9,25 +9,26 @@ provider "google" {
 }
 
 resource "google_compute_address" "example" {
-    name = "example-address"
+  name = "example-address"
 }
 
 resource "google_compute_instance_template" "example" {
-  machine_type   = "f1-micro"
-
+  machine_type = "f1-micro"
 
   disk {
     source_image = "ubuntu-1604-lts"
+    boot         = true
   }
 
   network_interface {
     network = "default"
+
     #access_config {
     #  // Ephemeral IP
     #}
   }
 
-  metadata_startup_script = "echo 'Hello, World' > index.html ; nohup busybox httpd -f -p ${var.server_port} &"
+  metadata_startup_script = "echo \"Hello from <h2>`hostname`<h2/>\" > index.html ; nohup busybox httpd -f -p ${var.server_port} &"
 }
 
 resource "google_compute_forwarding_rule" "example" {
@@ -38,7 +39,7 @@ resource "google_compute_forwarding_rule" "example" {
 }
 
 resource "google_compute_target_pool" "example" {
-  name = "example-target-pool"
+  name          = "example-target-pool"
   health_checks = ["${google_compute_http_health_check.example.name}"]
 }
 
@@ -52,8 +53,8 @@ resource "google_compute_instance_group_manager" "example" {
 }
 
 resource "google_compute_autoscaler" "example" {
-  name = "example-autoscaler"
-  zone = "us-central1-a"
+  name   = "example-autoscaler"
+  zone   = "us-central1-a"
   target = "${google_compute_instance_group_manager.example.self_link}"
 
   autoscaling_policy = {
@@ -68,11 +69,11 @@ resource "google_compute_autoscaler" "example" {
 }
 
 resource "google_compute_backend_service" "example" {
-  name = "example-backend-service"
-  port_name = "http"
-  protocol = "HTTP"
+  name        = "example-backend-service"
+  port_name   = "http"
+  protocol    = "HTTP"
   timeout_sec = 10
-  enable_cdn = false
+  enable_cdn  = false
 
   backend {
     group = "${google_compute_instance_group_manager.example.instance_group}"
@@ -81,17 +82,15 @@ resource "google_compute_backend_service" "example" {
   health_checks = ["${google_compute_http_health_check.example.self_link}"]
 }
 
-
 resource "google_compute_http_health_check" "example" {
-  name                 = "example-health-check"
-  request_path         = "/"
-  check_interval_sec   = 30
-  timeout_sec          = 3
-  healthy_threshold    = 2
-  unhealthy_threshold  = 2
-  port                 = "${var.server_port}"
+  name                = "example-health-check"
+  request_path        = "/"
+  check_interval_sec  = 30
+  timeout_sec         = 3
+  healthy_threshold   = 2
+  unhealthy_threshold = 2
+  port                = "${var.server_port}"
 }
-
 
 resource "google_compute_firewall" "instance" {
   name    = "example-firewall-instance"


### PR DESCRIPTION
Google Compute Engine no more support `disk` , used `boot_disk` instead.